### PR TITLE
updated `onRendered` syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ To use
 Set up your markup, in the example below a grouped calendar icon with text input (bootstrap3)
 
 ```html
-<template name="temName">
+<template name="tempName">
 ...
   <div class="input-group datetimepicker">
     <span class="input-group-addon"><i class="fa fa-calendar"></i></span>
@@ -29,7 +29,7 @@ Set up your markup, in the example below a grouped calendar icon with text input
 Using jQuery initiate the control as datetime picker after the template has been rendered.
 
 ```js
-Template.tempName.rendered = function() {
-    $('.datetimepicker').datetimepicker();
-}
+Template.tempName.onRendered(function() {
+    this.$('.datetimepicker').datetimepicker();
+});
 ```


### PR DESCRIPTION
Some small README.md changes…

1.  `Template.tempName.onRendered(function() { … })` is the syntax instead of `Template.tempName.rendered = function() { … }`. It allows for attaching multiple events.

2.  Do a jQuery selector within the given template only, `this.$(…)` is the proper syntax.

3.  Typo fix `tempName`