### PR TITLE
Size fix

### DIFF
--- a/lib/js/bootstrap-datetimepicker.js
+++ b/lib/js/bootstrap-datetimepicker.js
@@ -2302,7 +2302,7 @@
             input = element;
         } else {
             input = element.find(options.datepickerInput);
-            if (input.size() === 0) {
+            if (input.length === 0) {
                 input = element.find('input');
             } else if (!input.is('input')) {
                 throw new Error('CSS class "' + options.datepickerInput + '" cannot be applied to non input element');
@@ -2311,7 +2311,7 @@
 
         if (element.hasClass('input-group')) {
             // in case there is more then one 'input-group-addon' Issue #48
-            if (element.find('.datepickerbutton').size() === 0) {
+            if (element.find('.datepickerbutton').length === 0) {
                 component = element.find('.input-group-addon');
             } else {
                 component = element.find('.datepickerbutton');


### PR DESCRIPTION
`input.size` is `undefined` in google chrome usign the last jquery version.

More information https://api.jquery.com/size/
```
The .size() method is deprecated as of jQuery 1.8. Use the .length property instead.
```